### PR TITLE
Derive Debug for Memory and MemorySection

### DIFF
--- a/lib/ld-memory/src/lib.rs
+++ b/lib/ld-memory/src/lib.rs
@@ -12,6 +12,7 @@ use std::num::ParseIntError;
 use std::path::Path;
 use std::result::Result;
 
+#[derive(Debug)]
 pub struct Memory {
     sections: Vec<MemorySection>,
 }
@@ -74,6 +75,7 @@ impl Memory {
     }
 }
 
+#[derive(Debug)]
 pub struct MemorySection {
     name: String,
     attrs: Option<String>,


### PR DESCRIPTION
This is useful when somewhere down the line you quickly want to see what you just created `from_env_with_prefix`, eg. using `dbg!()` around it.

This could be a tad smoother by always picking hex mode, but then again it'd need manual debug code rather than going all derive, and it'd be more than two trivial lines.

Example output, from adding an `eprintln!("{:#x?}", &memory)` into the tool:

```
$ cargo run -- --section rom:0x0:1024K:128 --section empty:: --section other:0x0+128K:1K+7K
   Compiling ld-memory-cli v0.2.8 (/home/chrysn/git/crates/ld-memory/tools/ld-memory)
    Finished dev [unoptimized + debuginfo] target(s) in 0.28s
     Running `/home/chrysn/.cache/cargo-target/debug/ld-memory --section 'rom:0x0:1024K:128' --section 'empty::' --section 'other:0x0+128K:1K+7K'`
Memory {
    sections: [
        MemorySection {
            name: "rom",
            attrs: None,
            origin: 0x80,
            length: 0xfff80,
            pagesize: 0x1,
        },
        MemorySection {
            name: "empty",
            attrs: None,
            origin: 0x0,
            length: 0x0,
            pagesize: 0x1,
        },
        MemorySection {
            name: "other",
            attrs: None,
            origin: 0x20000,
            length: 0x2000,
            pagesize: 0x1,
        },
    ],
}
_rom_start = 0x80;
_rom_length = 0xFFF80;
_empty_start = 0x0;
_empty_length = 0x0;
_other_start = 0x20000;
_other_length = 0x2000;

MEMORY
{
    rom : ORIGIN = 0x80, LENGTH = 0xFFF80
    empty : ORIGIN = 0x0, LENGTH = 0x0
    other : ORIGIN = 0x20000, LENGTH = 0x2000
}
```