### PR TITLE
refactor!: rename to_string to to_ldmemory

### DIFF
--- a/lib/ld-memory/README.md
+++ b/lib/ld-memory/README.md
@@ -18,7 +18,7 @@ pub fn main() {
         .add_section(MemorySection::new("FLASH", 0, 0x40000))
         .add_section(MemorySection::new("RAM", 0x20000000, 0x10000));
 
-    println!("{}", memory.to_string());
+    println!("{}", memory.to_ldmemory());
 }
 ```
 

--- a/lib/ld-memory/src/lib.rs
+++ b/lib/ld-memory/src/lib.rs
@@ -30,7 +30,7 @@ impl Memory {
         Memory { sections }
     }
 
-    pub fn to_string(&self) -> String {
+    pub fn to_ldmemory(&self) -> String {
         let mut out = String::new();
 
         // create symbols for each section start and length
@@ -53,14 +53,14 @@ impl Memory {
 
         out.push_str("MEMORY\n{\n");
         for section in &self.sections {
-            out.push_str(&section.to_string());
+            out.push_str(&section.to_ldmemory());
         }
         out.push_str("}\n");
         out
     }
 
     pub fn to_file<P: AsRef<Path>>(&self, path: P) -> std::io::Result<()> {
-        std::fs::write(path, self.to_string())
+        std::fs::write(path, self.to_ldmemory())
     }
 
     #[cfg(feature = "build-rs")]
@@ -259,7 +259,7 @@ impl MemorySection {
         }
     }
 
-    pub fn to_string(&self) -> String {
+    pub fn to_ldmemory(&self) -> String {
         format!(
             "    {} {}: ORIGIN = {:#X}, LENGTH = {:#X}\n",
             self.name,
@@ -382,14 +382,14 @@ mod tests {
     #[test]
     fn basic_memory() {
         let memory = Memory::new();
-        assert_eq!(memory.to_string(), "MEMORY\n{\n}\n");
+        assert_eq!(memory.to_ldmemory(), "MEMORY\n{\n}\n");
     }
 
     #[test]
     fn basic_section() {
         let section = MemorySection::new("SectionName", 0, 0xFFFF);
         assert_eq!(
-            section.to_string(),
+            section.to_ldmemory(),
             "    SectionName : ORIGIN = 0x0, LENGTH = 0xFFFF\n"
         );
     }
@@ -398,7 +398,7 @@ mod tests {
     fn section_offset() {
         let section = MemorySection::new("SectionName", 0, 0x10000).offset(0x1000);
         assert_eq!(
-            section.to_string(),
+            section.to_ldmemory(),
             "    SectionName : ORIGIN = 0x1000, LENGTH = 0xF000\n"
         );
     }
@@ -407,7 +407,7 @@ mod tests {
     fn section_attrs() {
         let section = MemorySection::new("SectionName", 0, 0x10000).attrs("r!w!x");
         assert_eq!(
-            section.to_string(),
+            section.to_ldmemory(),
             "    SectionName (r!w!x): ORIGIN = 0x0, LENGTH = 0x10000\n"
         );
     }
@@ -421,7 +421,7 @@ mod tests {
         );
 
         assert_eq!(
-            memory.to_string(),
+            memory.to_ldmemory(),
             concat!(
                 "_SectionName_start = 0x1000;\n",
                 "_SectionName_length = 0xF000;\n",

--- a/tools/ld-memory/src/main.rs
+++ b/tools/ld-memory/src/main.rs
@@ -27,7 +27,7 @@ pub fn main() {
         memory = memory.add_section(section);
     }
 
-    println!("{}", memory.to_string());
+    println!("{}", memory.to_ldmemory());
 
     for include in args.includes {
         println!("INCLUDE {include}");


### PR DESCRIPTION
to_string is usually provided by the [Display trait](https://doc.rust-lang.org/std/fmt/trait.Display.html) and such it risks that users assume this provides a human readable string. This is currently not the case in this crate.

This API change renames the to_string method to to_ldmemory to clarify that the resulting string is formatted to a linker script format